### PR TITLE
Add EventHandler management services

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: alpha,beta,rc,projections,embeddings # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: eventhandlermanagement # Comma separated list of prerelease branch names. 'alpha,rc, ...'
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
           go-version: "1.16.2"
       - uses: arduino/setup-protoc@v1
         with:
-          version: "3.15.6"
+          version: "3.18.1"
       - run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
       - name: Generate code
         working-directory: ./Generation/Go
@@ -184,7 +184,7 @@ jobs:
           go-version: "1.16.2"
       - uses: arduino/setup-protoc@v1
         with:
-          version: "3.15.6"
+          version: "3.18.1"
       - run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
       - name: Generate code
         working-directory: ./Generation/Go

--- a/Generation/CSharp/Fundamentals/Fundamentals.csproj
+++ b/Generation/CSharp/Fundamentals/Fundamentals.csproj
@@ -8,6 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="2.0.6"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Fundamentals/Fundamentals.csproj
+++ b/Generation/CSharp/Fundamentals/Fundamentals.csproj
@@ -8,6 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Runtime/Runtime.csproj
+++ b/Generation/CSharp/Runtime/Runtime.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="2.0.6"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
     </ItemGroup>
     
 </Project>

--- a/Generation/CSharp/Runtime/Runtime.csproj
+++ b/Generation/CSharp/Runtime/Runtime.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
     </ItemGroup>
     
 </Project>

--- a/Generation/JavaScript/package.json
+++ b/Generation/JavaScript/package.json
@@ -5,7 +5,7 @@
     "Runtime"
   ],
   "devDependencies": {
-    "@dolittle/protobuf.build": "3.1.3",
+    "@dolittle/protobuf.build": "3.2.0-upgradetools.1",
     "typescript": "^3.8.3"
   }
 }

--- a/Generation/JavaScript/package.json
+++ b/Generation/JavaScript/package.json
@@ -5,7 +5,7 @@
     "Runtime"
   ],
   "devDependencies": {
-    "@dolittle/protobuf.build": "3.2.0-upgradetools.1",
+    "@dolittle/protobuf.build": "3.2.0",
     "typescript": "^3.8.3"
   }
 }

--- a/Source/Runtime/Embeddings/Embeddings.proto
+++ b/Source/Runtime/Embeddings/Embeddings.proto
@@ -10,7 +10,6 @@ import "Fundamentals/Services/CallContext.proto";
 import "Fundamentals/Services/ReverseCallContext.proto";
 import "Fundamentals/Services/Ping.proto";
 import "Runtime/Events/Uncommitted.proto";
-import "Runtime/Events.Processing/StreamEvent.proto";
 import "Runtime/Events.Processing/Processors.proto";
 import "Runtime/Events.Processing/Projections.proto";
 import "Runtime/Projections/State.proto";

--- a/Source/Runtime/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Events.Processing/EventHandlers.proto
@@ -22,7 +22,7 @@ message EventHandlerRegistrationRequest {
     protobuf.Uuid eventHandlerId = 3;
     repeated artifacts.Artifact eventTypes = 4;
     bool partitioned = 5;
-    string alias = 6;
+    optional string alias = 6;
 }
 
 message EventHandlerResponse {

--- a/Source/Runtime/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Events.Processing/EventHandlers.proto
@@ -22,7 +22,7 @@ message EventHandlerRegistrationRequest {
     protobuf.Uuid eventHandlerId = 3;
     repeated artifacts.Artifact eventTypes = 4;
     bool partitioned = 5;
-    optional string alias = 6;
+    string alias = 6;
 }
 
 message EventHandlerResponse {

--- a/Source/Runtime/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Events.Processing/EventHandlers.proto
@@ -22,6 +22,7 @@ message EventHandlerRegistrationRequest {
     protobuf.Uuid eventHandlerId = 3;
     repeated artifacts.Artifact eventTypes = 4;
     bool partitioned = 5;
+    optional string alias = 6;
 }
 
 message EventHandlerResponse {

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -11,7 +11,7 @@ import "Fundamentals/Services/Ping.proto";
 import "Runtime/Events.Processing/StreamEvent.proto";
 import "Runtime/Events.Processing/Processors.proto";
 
-package dolittle.runtime.events.processing.managament;
+package dolittle.runtime.events.processing.management;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/events/processing/management";

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -6,10 +6,6 @@ syntax = "proto3";
 import "Fundamentals/Artifacts/Artifact.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Protobuf/Failure.proto";
-import "Fundamentals/Services/ReverseCallContext.proto";
-import "Fundamentals/Services/Ping.proto";
-import "Runtime/Events.Processing/StreamEvent.proto";
-import "Runtime/Events.Processing/Processors.proto";
 
 package dolittle.runtime.events.processing.management;
 

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -59,4 +59,5 @@ message GetAllResponse {
 service EventHandlers {
     rpc ReprocessEventsFrom(ReprocessEventsFromRequest) returns(ReprocessEventsFromResponse);
     rpc ReprocessAllEvents(ReprocessAllEventsRequest) returns(ReprocessAllEventsResponse);
+    rpc GetAll(GetAllRequest) returns(GetAllResponse);
 }

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -37,6 +37,7 @@ message ReprocessAllEventsResponse {
 
 message GetAllRequest {
     // TODO: Do we want another kind of execution context here?
+    optional protobuf.Uuid tenantId = 1;
 }
 
 message EventHandlerStatus {
@@ -53,8 +54,21 @@ message GetAllResponse {
     repeated EventHandlerStatus eventHandlers = 2;
 }
 
+message GetOneRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid eventHandlerId = 2;
+    optional protobuf.Uuid tenantId = 3;
+}
+
+message GetOneResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    EventHandlerStatus eventHandlers = 2;
+}
+
 service EventHandlers {
     rpc ReprocessEventsFrom(ReprocessEventsFromRequest) returns(ReprocessEventsFromResponse);
     rpc ReprocessAllEvents(ReprocessAllEventsRequest) returns(ReprocessAllEventsResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);
+    rpc GetOne(GetOneRequest) returns(GetOneResponse);
 }

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 import "Fundamentals/Artifacts/Artifact.proto";
 import "Fundamentals/Protobuf/Uuid.proto";
 import "Fundamentals/Protobuf/Failure.proto";
+import "Runtime/Management/Events.Processing/StreamProcessors.proto";
 
 package dolittle.runtime.events.processing.management;
 

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -43,7 +43,7 @@ message EventHandlerStatus {
     protobuf.Uuid eventHandlerId = 2;
     repeated artifacts.Artifact eventTypes = 3;
     bool partitioned = 4;
-    optional string alias = 5;
+    string alias = 5;
     repeated TenantScopedEventHandlerStatus tenants = 6;
 }
 

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -25,7 +25,7 @@ message ReprocessEventsFromRequest {
 }
 
 message ReprocessEventsFromResponse {
-    protobuf.Failure failure = 1;
+    protobuf.Failure failure = 1; // not set if not failed
 }
 
 message ReprocessAllEventsRequest {
@@ -35,7 +35,25 @@ message ReprocessAllEventsRequest {
 }
 
 message ReprocessAllEventsResponse {
-    protobuf.Failure failure = 1;
+    protobuf.Failure failure = 1; // not set if not failed
+}
+
+message GetAllRequest {
+    // TODO: Do we want another kind of execution context here?
+}
+
+message EventHandlerStatus {
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid eventHandlerId = 2;
+    repeated artifacts.Artifact eventTypes = 3;
+    bool partitioned = 4;
+    optional string alias = 5;
+    repeated TenantScopedEventHandlerStatus tenants = 6;
+}
+
+message GetAllResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    repeated EventHandlerStatus eventHandlers = 2;
 }
 
 service EventHandlers {

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -45,7 +45,7 @@ message EventHandlerStatus {
     repeated artifacts.Artifact eventTypes = 3;
     bool partitioned = 4;
     string alias = 5;
-    repeated TenantScopedEventHandlerStatus tenants = 6;
+    repeated TenantScopedStreamProcessorStatus tenants = 6;
 }
 
 message GetAllResponse {

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -1,0 +1,44 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Artifacts/Artifact.proto";
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/ReverseCallContext.proto";
+import "Fundamentals/Services/Ping.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
+import "Runtime/Events.Processing/Processors.proto";
+
+package dolittle.runtime.events.processing.managament;
+
+option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing/management";
+
+message ReprocessEventsFromRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid tenantId = 1;
+    protobuf.Uuid scopeId = 2;
+    protobuf.Uuid eventHandlerId = 3;
+    uint64 streamPosition = 4;
+}
+
+message ReprocessEventsFromResponse {
+    protobuf.Failure failure = 1;
+}
+
+message ReprocessAllEventsRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid eventHandlerId = 2;
+}
+
+message ReprocessAllEventsResponse {
+    protobuf.Failure failure = 1;
+}
+
+service EventHandlers {
+    rpc ReprocessEventsFrom(ReprocessEventsFromRequest) returns(ReprocessEventsFromResponse);
+    rpc ReprocessAllEvents(ReprocessAllEventsRequest) returns(ReprocessAllEventsResponse);
+}

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -3,14 +3,6 @@
 
 syntax = "proto3";
 
-import "Fundamentals/Artifacts/Artifact.proto";
-import "Fundamentals/Protobuf/Uuid.proto";
-import "Fundamentals/Protobuf/Failure.proto";
-import "Fundamentals/Services/ReverseCallContext.proto";
-import "Fundamentals/Services/Ping.proto";
-import "Runtime/Events.Processing/StreamEvent.proto";
-import "Runtime/Events.Processing/Processors.proto";
-
 package dolittle.runtime.events.processing.management;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -3,6 +3,7 @@
 
 syntax = "proto3";
 
+import "Fundamentals/Protobuf/Uuid.proto";
 import "google/protobuf/timestamp.proto";
 
 package dolittle.runtime.events.processing.management;

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -1,0 +1,33 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+syntax = "proto3";
+
+import "Fundamentals/Artifacts/Artifact.proto";
+import "Fundamentals/Protobuf/Uuid.proto";
+import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/ReverseCallContext.proto";
+import "Fundamentals/Services/Ping.proto";
+import "Runtime/Events.Processing/StreamEvent.proto";
+import "Runtime/Events.Processing/Processors.proto";
+
+package dolittle.runtime.events.processing.management;
+
+option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";
+option go_package = "go.dolittle.io/contracts/runtime/events/processing/management";
+
+message UnpartitionedTenantScopedStreamProcessorStatus {
+    bool isFailing = 1;
+    string failureReason = 2;
+    uint32 retryCount = 3;
+    google.protobuf.Timestamp retryTime = 4;
+}
+
+message PartitionedTenantScopedStreamProcessorStatus {
+
+}
+
+message TenantScopedStreamProcessorStatus {
+    uint64 streamPosition = 1;
+    google.protobuf.Timestamp lastSuccessfullyProcessed = 2;
+}

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -3,6 +3,8 @@
 
 syntax = "proto3";
 
+import "google/protobuf/timestamp.proto";
+
 package dolittle.runtime.events.processing.management;
 
 option csharp_namespace = "Dolittle.Runtime.Events.Processing.Management.Contracts";

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -30,10 +30,11 @@ message FailingPartition {
 }
 
 message TenantScopedStreamProcessorStatus {
-    uint64 streamPosition = 1;
-    google.protobuf.Timestamp lastSuccessfullyProcessed = 2;
+    protobuf.Uuid tenantId = 1;
+    uint64 streamPosition = 2;
+    google.protobuf.Timestamp lastSuccessfullyProcessed = 3;
     oneof Status {
-        UnpartitionedTenantScopedStreamProcessorStatus unpartitioned = 3;
-        PartitionedTenantScopedStreamProcessorStatus partitioned = 4;
+        UnpartitionedTenantScopedStreamProcessorStatus unpartitioned = 4;
+        PartitionedTenantScopedStreamProcessorStatus partitioned = 5;
     }
 }

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -19,15 +19,16 @@ message UnpartitionedTenantScopedStreamProcessorStatus {
 }
 
 message PartitionedTenantScopedStreamProcessorStatus {
-    map<string, FailingPartition> failingPartitions = 1;
+    repeated FailingPartition failingPartitions = 1;
 }
 
 message FailingPartition {
-    uint64 streamPosition = 1;
-    string failureReason = 2;
-    uint32 retryCount = 3;
-    google.protobuf.Timestamp retryTime = 4;
-    google.protobuf.Timestamp lastFailed = 5;
+    string partitionId = 1;
+    uint64 streamPosition = 2;
+    string failureReason = 3;
+    uint32 retryCount = 4;
+    google.protobuf.Timestamp retryTime = 5;
+    google.protobuf.Timestamp lastFailed = 6;
 }
 
 message TenantScopedStreamProcessorStatus {

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -24,10 +24,22 @@ message UnpartitionedTenantScopedStreamProcessorStatus {
 }
 
 message PartitionedTenantScopedStreamProcessorStatus {
+    map<string, FailingPartition> failingPartitions = 1;
+}
 
+message FailingPartition {
+    uint64 streamPosition = 1;
+    string failureReason = 2;
+    uint32 retryCount = 3;
+    google.protobuf.Timestamp retryTime = 4;
+    google.protobuf.Timestamp lastFailed = 5;
 }
 
 message TenantScopedStreamProcessorStatus {
     uint64 streamPosition = 1;
     google.protobuf.Timestamp lastSuccessfullyProcessed = 2;
+    oneof Status {
+        UnpartitionedTenantScopedStreamProcessorStatus unpartitioned = 3;
+        PartitionedTenantScopedStreamProcessorStatus partitioned = 4;
+    }
 }


### PR DESCRIPTION
## Summary

Adds a management surface to Event Handlers that has the capability to reprocess event for Event Handlers and also get information about running Event Handlers. Also adds the possibility to register Event Handlers with named aliases for easy tracking. 

### Added

- Adds optional string 'alias' to event handler registration
- Adds management service for event handlers with 4 endpoints: `ReprocessEventsFrom`, `ReprocessAllEvents`, `GetAll` and `GetOne`

### Changed

- Updated Grpc and protobuf dependencies
