### PR TITLE
Upgrade Protobuf, add GetOne, and change structure from map to list

### DIFF
--- a/Generation/CSharp/Fundamentals/Fundamentals.csproj
+++ b/Generation/CSharp/Fundamentals/Fundamentals.csproj
@@ -8,6 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
     </ItemGroup>
 </Project>

--- a/Generation/CSharp/Runtime/Runtime.csproj
+++ b/Generation/CSharp/Runtime/Runtime.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="Dolittle.Common" Version="2.*" PrivateAssets="All"/>
-        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0-upgradetools.1"/>
+        <PackageReference Include="Dolittle.Protobuf.MSBuild" Version="3.2.0"/>
     </ItemGroup>
     
 </Project>

--- a/Generation/JavaScript/package.json
+++ b/Generation/JavaScript/package.json
@@ -5,7 +5,7 @@
     "Runtime"
   ],
   "devDependencies": {
-    "@dolittle/protobuf.build": "3.2.0-upgradetools.1",
+    "@dolittle/protobuf.build": "3.2.0",
     "typescript": "^3.8.3"
   }
 }

--- a/Source/Runtime/Management/Events.Processing/EventHandlers.proto
+++ b/Source/Runtime/Management/Events.Processing/EventHandlers.proto
@@ -37,6 +37,7 @@ message ReprocessAllEventsResponse {
 
 message GetAllRequest {
     // TODO: Do we want another kind of execution context here?
+    optional protobuf.Uuid tenantId = 1;
 }
 
 message EventHandlerStatus {
@@ -53,8 +54,21 @@ message GetAllResponse {
     repeated EventHandlerStatus eventHandlers = 2;
 }
 
+message GetOneRequest {
+    // TODO: Do we want another kind of execution context here?
+    protobuf.Uuid scopeId = 1;
+    protobuf.Uuid eventHandlerId = 2;
+    optional protobuf.Uuid tenantId = 3;
+}
+
+message GetOneResponse {
+    protobuf.Failure failure = 1; // not set if not failed
+    EventHandlerStatus eventHandlers = 2;
+}
+
 service EventHandlers {
     rpc ReprocessEventsFrom(ReprocessEventsFromRequest) returns(ReprocessEventsFromResponse);
     rpc ReprocessAllEvents(ReprocessAllEventsRequest) returns(ReprocessAllEventsResponse);
     rpc GetAll(GetAllRequest) returns(GetAllResponse);
+    rpc GetOne(GetOneRequest) returns(GetOneResponse);
 }

--- a/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
+++ b/Source/Runtime/Management/Events.Processing/StreamProcessors.proto
@@ -19,15 +19,16 @@ message UnpartitionedTenantScopedStreamProcessorStatus {
 }
 
 message PartitionedTenantScopedStreamProcessorStatus {
-    map<string, FailingPartition> failingPartitions = 1;
+    repeated FailingPartition failingPartitions = 1;
 }
 
 message FailingPartition {
-    uint64 streamPosition = 1;
-    string failureReason = 2;
-    uint32 retryCount = 3;
-    google.protobuf.Timestamp retryTime = 4;
-    google.protobuf.Timestamp lastFailed = 5;
+    string partitionId = 1;
+    uint64 streamPosition = 2;
+    string failureReason = 3;
+    uint32 retryCount = 4;
+    google.protobuf.Timestamp retryTime = 5;
+    google.protobuf.Timestamp lastFailed = 6;
 }
 
 message TenantScopedStreamProcessorStatus {


### PR DESCRIPTION
- Upgrade protobuf project references
- Add a GetOne endpoint for EventHandler management
- Add optional TenantID filter to GetAll/GetOne
- Change failing partitions structure from map to repeated