### PR TITLE
Change AggregateRoot registration so we can do cool things in the future

### DIFF
--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -5,21 +5,23 @@ syntax = "proto3";
 
 import "Fundamentals/Artifacts/Artifact.proto";
 import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/CallContext.proto";
 
 package dolittle.runtime.aggregates;
 
 option csharp_namespace = "Dolittle.Runtime.Aggregates.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/aggregates";
 
-message AggregateRootRegistrationRequest {
-    artifacts.Artifact aggregateRoot = 1;
-    optional string alias = 2;
+message AggregateRootAliasRegistrationRequest {
+    services.CallRequestContext callContext = 1;
+    artifacts.Artifact aggregateRoot = 2;
+    optional string alias = 3;
 }
 
-message AggregateRootRegistrationResponse {
+message AggregateRootAliasRegistrationResponse {
     protobuf.Failure failure = 1;
 }
 
 service AggregateRoots {
-    rpc Register(AggregateRootRegistrationRequest) returns(AggregateRootRegistrationResponse);
+    rpc RegisterAlias(AggregateRootRegistrationRequest) returns(AggregateRootRegistrationResponse);
 }

--- a/Source/Runtime/Aggregates/AggregateRoots.proto
+++ b/Source/Runtime/Aggregates/AggregateRoots.proto
@@ -23,5 +23,5 @@ message AggregateRootAliasRegistrationResponse {
 }
 
 service AggregateRoots {
-    rpc RegisterAlias(AggregateRootRegistrationRequest) returns(AggregateRootRegistrationResponse);
+    rpc RegisterAlias(AggregateRootAliasRegistrationRequest) returns(AggregateRootAliasRegistrationResponse);
 }

--- a/Source/Runtime/Embeddings/Store.proto
+++ b/Source/Runtime/Embeddings/Store.proto
@@ -14,18 +14,18 @@ option csharp_namespace = "Dolittle.Runtime.Embeddings.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/embeddings";
 
 message GetOneRequest {
-    services.CallRequestContext callContext = 1; 
+    services.CallRequestContext callContext = 1;
     protobuf.Uuid embeddingId = 2;
     string key = 3;
 }
 
 message GetKeysRequest {
-    services.CallRequestContext callContext = 1; 
+    services.CallRequestContext callContext = 1;
     protobuf.Uuid embeddingId = 2;
 }
 
 message GetAllRequest {
-    services.CallRequestContext callContext = 1; 
+    services.CallRequestContext callContext = 1;
     protobuf.Uuid embeddingId = 2;
 }
 

--- a/Source/Runtime/Events/EventTypes.proto
+++ b/Source/Runtime/Events/EventTypes.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 
 import "Fundamentals/Artifacts/Artifact.proto";
 import "Fundamentals/Protobuf/Failure.proto";
+import "Fundamentals/Services/CallContext.proto";
 
 package dolittle.runtime.events;
 
@@ -12,8 +13,9 @@ option csharp_namespace = "Dolittle.Runtime.Events.Contracts";
 option go_package = "go.dolittle.io/contracts/runtime/events";
 
 message EventTypeRegistrationRequest {
-    artifacts.Artifact eventType = 1;
-    optional string alias = 2;
+    services.CallRequestContext callContext = 1;
+    artifacts.Artifact eventType = 2;
+    optional string alias = 3;
 }
 
 message EventTypeRegistrationResponse {


### PR DESCRIPTION
Rename AggregateRoot registration so that we can implement them with Commands/Actions in the future with ReverseCallClients. Also add CallContext on the new registration calls.