### PR TITLE
Sam: Copy Projection read models to MongoDB for querying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Contracts CI/CD
 
 env:
-  PRERELEASE_BRANCHES: gimli # Comma separated list of prerelease branch names. 'alpha,rc, ...'
+  PRERELEASE_BRANCHES: sam # Comma separated list of prerelease branch names. 'alpha,rc, ...'
 
 on:
   push:

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -50,9 +50,17 @@ message ProjectionCopyToMongoDB {
     }
 
     enum BSONType {
-        NONE = 0;
-        DATE = 1;
-        GUID = 2;
+        None = 0;
+
+        DateAsDate = 1;
+        DateAsArray = 2;
+        DateAsDocument = 3;
+        DateAsString = 4;
+        DateAsInt64 = 5;
+
+        GUIDAsStandardBinary = 6;
+        GUIDAsCSharpLegacyBinary = 8;
+        GUIDAsString = 9;
     }
 }
 

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -37,12 +37,28 @@ message ProjectionEventSelector {
     }
 }
 
+message ProjectionCopyToMongoDB {
+    string collection = 1;
+    map<string, BSONType> conversions = 2;
+
+    enum BSONType {
+        DATE = 0;
+        TIMESTAMP = 1;
+        BINARY = 2;
+    }
+}
+
+message ProjectionCopies {
+    ProjectionCopyToMongoDB mongoDB = 1;
+}
+
 message ProjectionRegistrationRequest {
     services.ReverseCallArgumentsContext callContext = 1;
     protobuf.Uuid scopeId = 2;
     protobuf.Uuid projectionId = 3;
     repeated ProjectionEventSelector events = 4;
     string initialState = 5;
+    ProjectionCopies copies = 6;
 }
 
 message ProjectionReplaceResponse {

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -40,11 +40,11 @@ message ProjectionEventSelector {
 message ProjectionCopyToMongoDB {
     string collection = 1;
     map<string, BSONType> conversions = 2;
+    map<string, string> renamings = 3;
 
     enum BSONType {
         DATE = 0;
-        TIMESTAMP = 1;
-        BINARY = 2;
+        GUID = 1;
     }
 }
 

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -11,6 +11,7 @@ import "Fundamentals/Services/Ping.proto";
 import "Runtime/Events.Processing/StreamEvent.proto";
 import "Runtime/Events.Processing/Processors.proto";
 import "Runtime/Projections/State.proto";
+import "google/protobuf/wrappers.proto";
 
 package dolittle.runtime.events.processing;
 
@@ -39,12 +40,19 @@ message ProjectionEventSelector {
 
 message ProjectionCopyToMongoDB {
     string collection = 1;
-    map<string, BSONType> conversions = 2;
-    map<string, string> renamings = 3;
+    repeated PropertyConversion conversions = 2;
+
+    message PropertyConversion {
+        string propertyName = 1;
+        BSONType convertTo = 2;
+        google.protobuf.StringValue renameTo = 3;
+        repeated PropertyConversion children = 4;
+    }
 
     enum BSONType {
-        DATE = 0;
-        GUID = 1;
+        NONE = 1;
+        DATE = 1;
+        GUID = 2;
     }
 }
 

--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -50,7 +50,7 @@ message ProjectionCopyToMongoDB {
     }
 
     enum BSONType {
-        NONE = 1;
+        NONE = 0;
         DATE = 1;
         GUID = 2;
     }


### PR DESCRIPTION
## Summary

Introduces secondary storage mechanisms for Projection read models, this enables using existing databases as query engines for read models.

### Added

- Copy read model specifications on `ProjectionRegistrationRequest`, to tell the Runtime to make copies of Projection read models to a secondary storage.
- MongoDB read model copies with BSON conversions and renaming support for converting Projection states (JSON) to BSON documents so that we can mimic how storing read models directly to a MongoDB collection would work from the SDKs.
