### PR TITLE
Add alias to ProjectionRegistrationRequest

### DIFF
--- a/Source/Runtime/Events.Processing/Projections.proto
+++ b/Source/Runtime/Events.Processing/Projections.proto
@@ -75,6 +75,7 @@ message ProjectionRegistrationRequest {
     repeated ProjectionEventSelector events = 4;
     string initialState = 5;
     ProjectionCopies copies = 6;
+    optional string alias = 7;
 }
 
 message ProjectionReplaceResponse {


### PR DESCRIPTION
## Summary

Add alias to ProjectionRegistrationRequest, so we can keep track of it.